### PR TITLE
Tooltips with exact posting time

### DIFF
--- a/my-templates/gamua/forum.php
+++ b/my-templates/gamua/forum.php
@@ -42,7 +42,7 @@ if (bb_get_forum_is_category())
 	<td class="num"><?php topic_posts(); ?></td>
 	<!-- <td class="num"><?php bb_topic_voices(); ?></td> -->
 	<td class="num"><?php topic_last_poster(); ?></td>
-	<td class="num"><a href="<?php topic_last_post_link(); ?>"><?php topic_time(); ?></a></td>
+	<td class="num"><a href="<?php topic_last_post_link(); ?>"><span title="<?php topic_time( array('format' => 'datetime') );?>"><?php topic_time(); ?></span></a></td>
 </tr>
 <?php endforeach; endif; ?>
 
@@ -52,7 +52,7 @@ if (bb_get_forum_is_category())
 	<td class="num"><?php topic_posts(); ?></td>
 	<!-- <td class="num"><?php bb_topic_voices(); ?></td> -->
 	<td class="num"><?php topic_last_poster(); ?></td>
-	<td class="num"><a href="<?php topic_last_post_link(); ?>"><?php topic_time(); ?></a></td>
+	<td class="num"><a href="<?php topic_last_post_link(); ?>"><span title="<?php topic_time( array('format' => 'datetime') );?>"><?php topic_time(); ?></span></a></td>
 </tr>
 <?php endforeach; endif; ?>
 </table>

--- a/my-templates/gamua/front-page.php
+++ b/my-templates/gamua/front-page.php
@@ -29,7 +29,7 @@
 	<td class="num"><?php topic_posts(); ?></td>
 	<!-- <td class="num"><?php bb_topic_voices(); ?></td> -->
 	<td class="num"><?php topic_last_poster(); ?></td>
-	<td class="num"><a href="<?php topic_last_post_link(); ?>"><?php topic_time(); ?></a></td>
+	<td class="num"><a href="<?php topic_last_post_link(); ?>"><span title="<?php topic_time( array('format' => 'datetime') );?>"><?php topic_time(); ?></span></a></td>
 </tr>
 <?php endforeach; endif; // $super_stickies ?>
 
@@ -39,7 +39,7 @@
 	<td class="num"><?php topic_posts(); ?></td>
 	<!-- <td class="num"><?php bb_topic_voices(); ?></td> -->
 	<td class="num"><?php topic_last_poster(); ?></td>
-	<td class="num"><a href="<?php topic_last_post_link(); ?>"><?php topic_time(); ?></a></td>
+	<td class="num"><a href="<?php topic_last_post_link(); ?>"><span title="<?php topic_time( array('format' => 'datetime') );?>"><?php topic_time(); ?></span></a></td>
 </tr>
 <?php endforeach; endif; // $topics ?>
 </table>

--- a/my-templates/gamua/post.php
+++ b/my-templates/gamua/post.php
@@ -8,6 +8,6 @@
 			</div>
 			<div class="threadpost">
 				<div class="post"><?php post_text(); ?></div>
-				<div class="poststuff"><?php printf( __('Posted %s ago'), bb_get_post_time() ); ?> <a href="<?php post_anchor_link(); ?>">#</a> <?php bb_post_admin(); ?></div>
+				<div class="poststuff"><span title="<?php bb_post_time( array('format' => 'datetime') );?>"><?php printf( __('Posted %s ago'), bb_get_post_time() ); ?></span> <a href="<?php post_anchor_link(); ?>">#</a> <?php bb_post_admin(); ?></div>
 			</div>
 		</div>


### PR DESCRIPTION
More than once, I've wanted to know the exact date I released a version of Feathers. The forum post is always my first announcement, so I usually want to check there. bbPress was showing only the relative date and time, which isn't super accurate when it says something like "Posted 3 months ago". I wrapped it with a span that has a title attribute with the exact date and time. Now, I'll be able to hover my mouse over the relative date and time to see the exact date and time in a tooltip.
